### PR TITLE
feat: lower python version to 3.9

### DIFF
--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os-version: ["ubuntu-22.04", "macos-14"]
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         poetry-version: ["1.8.3"]
 
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       matrix:
         os-version: ["ubuntu-22.04", "macos-14"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        #python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10"]
         poetry-version: ["1.8.3"]
 
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         os-version: ["ubuntu-22.04", "macos-14"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        #python-version: ["3.10"]
         poetry-version: ["1.8.3"]
 
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os-version: ["ubuntu-22.04", "macos-14"]
         #python-version: ["3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
         poetry-version: ["1.8.3"]
 
     runs-on: ${{ matrix.os-version }}

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       matrix:
         os-version: ["ubuntu-22.04", "macos-14"]
-        #python-version: ["3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        #python-version: ["3.10"]
         poetry-version: ["1.8.3"]
 
     runs-on: ${{ matrix.os-version }}
@@ -33,17 +33,16 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Setup vapoursynth
+        uses: deadnews/action-setup-vs@v1.0.5 # R70
 
       - uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ matrix.poetry-version }}
-
-      - name: Setup vapoursynth
-        uses: deadnews/action-setup-vs@v1.0.5
 
       - name: Test
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ version = "0.1.0"
 
 # Requirements
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.7.0"


### PR DESCRIPTION
## Summary by Sourcery

Expand Python support to versions 3.9, 3.11, and 3.12.

Enhancements:
- Update the minimum supported Python version to 3.9.

CI:
- Add Python 3.9, 3.11, and 3.12 to the CI test matrix.