### PR TITLE
chore: replace TensoRaws org URLs with EutropicAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI-test](https://github.com/EutropicAI/mbfunc/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/mbfunc/actions/workflows/CI-test.yml)
 [![Release](https://github.com/EutropicAI/mbfunc/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/mbfunc/actions/workflows/Release.yml)
 [![PyPI version](https://badge.fury.io/py/mbfunc.svg)](https://badge.fury.io/py/mbfunc)
-![GitHub](https://img.shields.io/github/license/TensoRaws/mbfunc)
+![GitHub](https://img.shields.io/github/license/EutropicAI/mbfunc)
 
 mbf's VapourSynth functions
 
@@ -20,4 +20,4 @@ pip install mbfunc
 ### License
 
 This project is licensed under the GPL-3.0 license - see
-the [LICENSE file](https://github.com/EutropicAI/mbfunc/blob/main/LICENSE) for details.
+the [LICENSE file](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mbfunc
 
-[![CI-test](https://github.com/TensoRaws/mbfunc/actions/workflows/CI-test.yml/badge.svg)](https://github.com/TensoRaws/mbfunc/actions/workflows/CI-test.yml)
-[![Release](https://github.com/TensoRaws/mbfunc/actions/workflows/Release.yml/badge.svg)](https://github.com/TensoRaws/mbfunc/actions/workflows/Release.yml)
+[![CI-test](https://github.com/EutropicAI/mbfunc/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/mbfunc/actions/workflows/CI-test.yml)
+[![Release](https://github.com/EutropicAI/mbfunc/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/mbfunc/actions/workflows/Release.yml)
 [![PyPI version](https://badge.fury.io/py/mbfunc.svg)](https://badge.fury.io/py/mbfunc)
 ![GitHub](https://img.shields.io/github/license/TensoRaws/mbfunc)
 
@@ -20,4 +20,4 @@ pip install mbfunc
 ### License
 
 This project is licensed under the GPL-3.0 license - see
-the [LICENSE file](https://github.com/TensoRaws/mbfunc/blob/main/LICENSE) for details.
+the [LICENSE file](https://github.com/EutropicAI/mbfunc/blob/main/LICENSE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 description = "mbf's VapourSynth functions"
-homepage = "https://github.com/TensoRaws/mbfunc"
+homepage = "https://github.com/EutropicAI/mbfunc"
 license = "GPL-3.0-only"
 name = "mbfunc"
 readme = "README.md"
-repository = "https://github.com/TensoRaws/mbfunc"
+repository = "https://github.com/EutropicAI/mbfunc"
 version = "0.1.1"
 
 # Requirements


### PR DESCRIPTION
We renamed the organization. This PR updates occurrences of:
- https://github.com/TensoRaws
to:
- https://github.com/EutropicAI

Notes:
- Only text-like files were modified; common binary/build paths skipped.
- Please review and merge when ready.
