### PR TITLE
chore: replace org URLs and LICENSE links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # mbfunc
 
-[![CI-test](https://github.com/TensoRaws/mbfunc/actions/workflows/CI-test.yml/badge.svg)](https://github.com/TensoRaws/mbfunc/actions/workflows/CI-test.yml)
-[![Release](https://github.com/TensoRaws/mbfunc/actions/workflows/Release.yml/badge.svg)](https://github.com/TensoRaws/mbfunc/actions/workflows/Release.yml)
+[![CI-test](https://github.com/EutropicAI/mbfunc/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/mbfunc/actions/workflows/CI-test.yml)
+[![Release](https://github.com/EutropicAI/mbfunc/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/mbfunc/actions/workflows/Release.yml)
 [![PyPI version](https://badge.fury.io/py/mbfunc.svg)](https://badge.fury.io/py/mbfunc)
-![GitHub](https://img.shields.io/github/license/TensoRaws/mbfunc)
+![GitHub](https://img.shields.io/github/license/EutropicAI/mbfunc)
 
 mbf's VapourSynth functions
 
@@ -20,4 +20,4 @@ pip install mbfunc
 ### License
 
 This project is licensed under the GPL-3.0 license - see
-the [LICENSE file](https://github.com/TensoRaws/mbfunc/blob/main/LICENSE) for details.
+the [LICENSE file](./LICENSE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ strict = true
 warn_return_any = false
 
 [tool.poetry]
-authors = ["TensoRaws"]
+authors = ["EutropicAI"]
 classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -32,11 +32,11 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 description = "mbf's VapourSynth functions"
-homepage = "https://github.com/TensoRaws/mbfunc"
+homepage = "https://github.com/EutropicAI/mbfunc"
 license = "GPL-3.0-only"
 name = "mbfunc"
 readme = "README.md"
-repository = "https://github.com/TensoRaws/mbfunc"
+repository = "https://github.com/EutropicAI/mbfunc"
 version = "0.1.1"
 
 # Requirements


### PR DESCRIPTION
This PR updates explicit org URLs and converts absolute LICENSE links to relative form.

Org URL replacements: 9
LICENSE link conversions (blob): 1
LICENSE link conversions (raw): 0

Old base: TensoRaws
New base: EutropicAI

Relative ./LICENSE links stay correct if branches or hosts change.